### PR TITLE
fix EDU-56: 로그아웃 accesstoken 헤더에 담기도록 수정 및 import 절대경로로 수정

### DIFF
--- a/src/api/axios.tsx
+++ b/src/api/axios.tsx
@@ -9,14 +9,13 @@ const api = axios.create({
 });
 
 /* 로컬 스토리지에 accesstoken 있으면 헤더에 추가 */
-api.interceptors.request.use((config: InternalAxiosRequestConfig ) => {
-  const token = localStorage.getItem('accesstoken');
-  
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("accesstoken");
+  console.debug("[interceptor] token:", token);   // 추가
+
   if (token) {
     config.headers = config.headers ?? {};
     config.headers.Authorization = `Bearer ${token}`;
-  } else if(config.headers) {
-    delete config.headers.Authorization;   // 토큰 없으면 제거
   }
   return config;
 });

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,4 +1,4 @@
-import '../styled/pages/mypage.css';
+import '@/styled/pages/mypage.css';
 import { useNavigate } from 'react-router-dom';
 
 function MyPage() {

--- a/src/pages/login/LogoutHandler.tsx
+++ b/src/pages/login/LogoutHandler.tsx
@@ -1,20 +1,16 @@
 // src/pages/auth/LogoutHandler.jsx
 import { useEffect } from "react";
 import { NavigateFunction, useNavigate } from "react-router-dom";
-import api from "../../api/axios";
+import api from "@/api/axios";
 
 export default function LogoutHandler() {
   const navigate: NavigateFunction = useNavigate();
 
   useEffect(() => {
-    /* 로컬 스토리지에서 토큰 가져오기 */
-    const accessToken: string | null = localStorage.getItem("accesstoken");
     (async () => {
       try {
         /* api 호출 */
-        await api.delete<void>("/api/user/signout", {
-          params: { accessToken },
-        });
+        await api.delete<void>("/api/user/signout");
       } catch (e) {
         console.warn("서버 로그아웃 요청 실패(무시)", e);
       }

--- a/src/pages/roadmap/Roadmap.tsx
+++ b/src/pages/roadmap/Roadmap.tsx
@@ -1,8 +1,8 @@
 // src/components/Roadmap.jsx
 import { useEffect, useState } from "react";
-import SubjectModal from "./Subject";
-import api from "../../api/axios"
-import "../../styled/pages/roadmap.css";
+import SubjectModal from "@/pages/roadmap/Subject";
+import api from "@/api/axios"
+import "@/styled/pages/roadmap.css";
 
 interface Answer {
   questionId: number;

--- a/src/pages/roadmap/Subject.tsx
+++ b/src/pages/roadmap/Subject.tsx
@@ -1,6 +1,6 @@
 // src/components/Subject.jsx
 import { useEffect, useState } from "react";
-import "../../styled/pages/subject.css";
+import "@/styled/pages/subject.css";
 
 export interface SubjectRef {
   subjectId: number;


### PR DESCRIPTION
EDU-56-FE-사용자-로드맵-화면-구성 -> develop

로그아웃 accesstoken 헤더에 담기도록 수정 및 import 절대경로로 수정